### PR TITLE
Upgrades EntityFrameworkCore from 2.2.4 to 2.2.6 | Change CryptoHelper to use Argon2id

### DIFF
--- a/Finances.Api/Controllers/AuthController.cs
+++ b/Finances.Api/Controllers/AuthController.cs
@@ -1,5 +1,5 @@
 ﻿using Finances.Common.Data;
-using Finances.Core.Application.Accounts.Commands;
+using Finances.Core.Application.Authorization.Commands.CreateAccount;
 using Finances.Core.Application.Authorization.Commands.SignIn;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/Finances.Api/Finances.Api.csproj
+++ b/Finances.Api/Finances.Api.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.16" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/Finances.Common/Finances.Common.csproj
+++ b/Finances.Common/Finances.Common.csproj
@@ -8,15 +8,10 @@
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
     <PackageReference Include="jose-jwt" Version="2.4.0" />
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.2.1" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnetcore.cryptography.keyderivation\2.2.0\lib\netcoreapp2.0\Microsoft.AspNetCore.Cryptography.KeyDerivation.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Finances.Common/MainScript.sql
+++ b/Finances.Common/MainScript.sql
@@ -25,7 +25,7 @@ create table `finances`.`user`
 (
 	`id` varchar(36) not null primary key,
     `username` varchar(40) not null,
-    `password` varchar(125) not null,
+    `password` varchar(256) not null,
     `status` int(1) not null,
     `created_date` timestamp default current_timestamp not null,
     `updated_date` timestamp default current_timestamp not null,

--- a/Finances.Core/Application/Authorization/Commands/CreateAccount/CreateAccountValidator.cs
+++ b/Finances.Core/Application/Authorization/Commands/CreateAccount/CreateAccountValidator.cs
@@ -22,12 +22,7 @@ namespace Finances.Core.Application.Authorization.Commands.CreateAccount
             RuleFor(x => x.ImagePath).Length(500).Must(BeAValidUrl).WithMessage("O e-mail informado não é válido");
         }
 
-        private bool BeMaleOrFemale(char gender)
-        {
-            if (gender == 'm' || gender == 'M' || gender == 'f' || gender == 'F')
-                return true;
-            return false;
-        }
+        private bool BeMaleOrFemale(char gender) => gender.ToLower() == 'm' || gender.ToLower() == 'f';
 
         private bool DontHaveMask(string phone)
         {

--- a/Finances.Core/Application/Authorization/Commands/SignIn/SignInHandler.cs
+++ b/Finances.Core/Application/Authorization/Commands/SignIn/SignInHandler.cs
@@ -41,7 +41,7 @@ namespace Finances.Core.Application.Authorization.Commands.SignIn
                     Message = "Login e/ou senha incorretos."
                 };
 
-            if (!cryptoHelper.Valid(request.Password, login.Password))
+            if (!cryptoHelper.IsValid(request.Password, login.Password))
                 return new JsonDefaultResponse
                 {
                     Success = false,


### PR DESCRIPTION
1. Changes Finances.Api/Finances.Api.csproj to reference Microsoft.EntityFrameworkCore and Microsoft.EntityFrameworkCore.Relational 2.2.6 instead of 2.2.4

2. Changes the implementation of CryptoHelper to use Argon2id instead of the pbkdf2 from https://cmatskas.com/-net-password-hashing-using-pbkdf2/
Argument for using Argon2: https://security.stackexchange.com/questions/193351/in-2018-what-is-the-recommended-hash-to-store-passwords-bcrypt-scrypt-argon2